### PR TITLE
fix: update CI to verify 241 tests (not 105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         run: |
           python -m pytest tests/ -v --cov=mcp_monitor --cov-report=term-missing
 
-      - name: Verify 105 tests collected
+      - name: Verify 241 tests collected
         run: |
           count=$(python -m pytest tests/ --collect-only -q 2>/dev/null | tail -1 | grep -oP '\d+(?= tests)')
-          if [ "$count" != "105" ]; then
-            echo "Expected 105 tests, got $count"
+          if [ "$count" != "241" ]; then
+            echo "Expected 241 tests, got $count"
             exit 1
           fi


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @poojakira :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Fixes the CI failure:

**Problem:** CI checked for 105 tests but the full implementation has 241 tests.

**Fix:** Changed `105` → `241` in the test count verification step.

**Author:** poojakira

This is a one-line fix to `.github/workflows/ci.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated continuous integration checks to validate the expanded test suite.
  * CI now expects 241 collected tests and reports a clear failure when the count differs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->